### PR TITLE
Auto requires

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,3 @@ gemspec
 
 gem "rake", "~> 13.0"
 
-gem "minitest", "~> 5.14"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    byebug (11.1.3)
     minitest (5.14.4)
     rack (2.2.3)
     rake (13.0.3)
@@ -15,6 +16,7 @@ PLATFORMS
   x86_64-darwin-20
 
 DEPENDENCIES
+  byebug
   minitest (~> 5.14)
   rake (~> 13.0)
   rulers!

--- a/lib/rulers.rb
+++ b/lib/rulers.rb
@@ -2,8 +2,27 @@
 
 require_relative "rulers/version"
 
+class Object
+  def self.const_missing(c)
+    require Rulers.to_underscore(c.to_s)
+    const_get(c)
+  end
+end
+
 module Rulers
   class Error < StandardError; end
+
+  # TODO: add test
+  def self.to_underscore(s)
+    s.gsub(
+      /([A-Z]+)([A-Z][a-z])/,
+      '\1_\2'
+    ).gsub(
+      /([a-z\d])([A-Z])/,
+      '\1_\2'
+    ).downcase
+  end
+
   class Controller
     attr_reader(:env)
 

--- a/rulers.gemspec
+++ b/rulers.gemspec
@@ -26,6 +26,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency("rack", "~>2")
+  spec.add_development_dependency("minitest", "~> 5.14")
+  spec.add_development_dependency("byebug")
 
   # For more information and examples about making a new gem, checkout our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/test/fixtures/requires/test_controller.rb
+++ b/test/fixtures/requires/test_controller.rb
@@ -1,0 +1,2 @@
+class TestController < Rulers::Controller
+end

--- a/test/rulers_test.rb
+++ b/test/rulers_test.rb
@@ -19,4 +19,19 @@ class RulersTest < Minitest::Test
     assert_equal(200, ::Rulers::App.new.call(env)[0])
     assert_equal([TedController.new(nil).think], ::Rulers::App.new.call(env)[2])
   end
+
+  def test_to_underscore
+    assert_equal("foo", Rulers.to_underscore("foo"))
+    assert_equal("foo", Rulers.to_underscore("FOO"))
+    assert_equal("foo_bar", Rulers.to_underscore("FooBar"))
+    assert_equal("foo_bar", Rulers.to_underscore("FOOBar"))
+    assert_equal("with2_numbers", Rulers.to_underscore("With2Numbers"))
+  end
+
+  def test_autorequire
+    assert_raises(LoadError) { TestController }
+    path = File.expand_path("fixtures/requires", __dir__)
+    $LOAD_PATH << path
+    assert(TestController)
+  end
 end


### PR DESCRIPTION
Section 3 of "Rebuilding Rails": implementing auto-requiring of files via monkey-patching of `const_missing`. Ideally a refinement would be better, but I don't think that's possible due to the indirect aspect of the override.

This also brings in `byebug` as a development dependeny