### PR TITLE
Add render method to controller base class

### DIFF
--- a/lib/rulers.rb
+++ b/lib/rulers.rb
@@ -23,11 +23,19 @@ module Rulers
     ).downcase
   end
 
+  require "erb"
   class Controller
     attr_reader(:env)
 
     def initialize(env)
       @env = env
+    end
+
+    # default binding is that of the caller
+    def render(name, b = binding())
+      template = "app/views/#{name}.html.erb"
+      e = ERB.new(File.read(template))
+      e.result(b)
     end
   end
 


### PR DESCRIPTION
Section 4 of Rebuilding Rails: implementing a basic render method in the base `Rulers::Controller` class.