### PR TITLE
Params wrapper of Rack::Request

### DIFF
--- a/lib/rulers.rb
+++ b/lib/rulers.rb
@@ -31,6 +31,14 @@ module Rulers
       @env = env
     end
 
+    def request
+      @request ||= Rack::Request.new(env)
+    end
+
+    def params
+      request.params
+    end
+
     # default binding is that of the caller
     def render(name, b = binding())
       template = "app/views/#{name}.html.erb"


### PR DESCRIPTION
Section 5 of Rebuilding Rails: adding basic support for params by hooking into `Rack::Request.new(env)`