### PR TITLE
Add basic view support

### DIFF
--- a/lib/rulers.rb
+++ b/lib/rulers.rb
@@ -5,6 +5,7 @@ require_relative "rulers/utils"
 require_relative "rulers/app"
 require_relative "rulers/controller"
 require_relative "rulers/file_model"
+require_relative "rulers/config"
 
 class Object
   class << self
@@ -21,4 +22,17 @@ end
 module Rulers
   extend Utils
   class Error < StandardError; end
+
+  # #config yields a free form config object to allow setting arbitrary
+  # configuration values to be consumed by the application
+  def self.config
+    @config ||= Config.new
+    if block_given?
+      @config.tap do |c|
+        yield c
+      end
+    else
+      @config
+    end
+  end
 end

--- a/lib/rulers.rb
+++ b/lib/rulers.rb
@@ -13,7 +13,7 @@ class Object
       require Rulers.to_underscore(c.to_s)
       const_get(c)
     rescue NameError, LoadError
-      original_const_missing
+      original_const_missing(c)
     end
   end
 end

--- a/lib/rulers/config.rb
+++ b/lib/rulers/config.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+require "ostruct"
+
+module Rulers
+  class Config < OpenStruct
+  end
+end

--- a/lib/rulers/controller.rb
+++ b/lib/rulers/controller.rb
@@ -17,10 +17,16 @@ module Rulers
       request.params
     end
 
-    def render(name, b = binding())
-      template = "app/views/#{name}.html.erb"
+    def render(view, b = binding())
+      template = File.expand_path("app/views/#{controller_name}/#{view}.html.erb", Rulers.config.root)
       e = ERB.new(File.read(template))
       e.result(b)
+    end
+
+    private
+
+    def controller_name
+      Utils.to_underscore(self.class.name).delete_suffix("_controller")
     end
   end
 end

--- a/lib/rulers/utils.rb
+++ b/lib/rulers/utils.rb
@@ -4,13 +4,13 @@ module Rulers
     extend(self)
     def to_underscore(s)
       s.gsub(/::/, "/")
-      .gsub(
-        /([A-Z]+)([A-Z][a-z])/,
-        '\1_\2'
-      ).gsub(
-        /([a-z\d])([A-Z])/,
-        '\1_\2'
-      ).downcase
+        .gsub(
+          /([A-Z]+)([A-Z][a-z])/,
+          '\1_\2'
+        ).gsub(
+          /([a-z\d])([A-Z])/,
+          '\1_\2'
+        ).downcase
     end
   end
 end

--- a/test/dummy_app/app/controllers/quotes_controller.rb
+++ b/test/dummy_app/app/controllers/quotes_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class QuotesController < Rulers::Controller
+  def a_quote
+    "May the fourth be with you"
+  end
+
+  def shakes
+    @noun = :winking
+    render(:shakes)
+  end
+
+  def card_trick
+    n = params["card"] || "Queen"
+    "Your card: the #{n} of spades!"
+  end
+
+  def fq
+    @q = Rulers::FileModel.find(params["q"] || 1)
+    render(:quote)
+  end
+end

--- a/test/dummy_app/app/controllers/root_controller.rb
+++ b/test/dummy_app/app/controllers/root_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RootController < Rulers::Controller
+  def index
+    "OK"
+  end
+end

--- a/test/dummy_app/app/views/quotes/quote.html.erb
+++ b/test/dummy_app/app/views/quotes/quote.html.erb
@@ -1,0 +1,6 @@
+<p>
+  &quot;<%= @q["text"] %>&quot;
+  <br /> - <%= @q["speaker"] %>
+
+  <pre><%= env %></pre>
+</p>

--- a/test/dummy_app/app/views/quotes/shakes.html.erb
+++ b/test/dummy_app/app/views/quotes/shakes.html.erb
@@ -1,0 +1,1 @@
+There is nothing either good or bad but <%= @noun %> makes it so.

--- a/test/dummy_app/config/dummy_app.rb
+++ b/test/dummy_app/config/dummy_app.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+require "rulers"
+$LOAD_PATH << File.join(File.dirname(__FILE__), "..", "app", "controllers")
+
+module DummyApp
+  class App < ::Rulers::App
+  end
+end

--- a/test/dummy_app/data/1.json
+++ b/test/dummy_app/data/1.json
@@ -1,0 +1,4 @@
+{
+  "text": "Ack!",
+  "speaker": "Cathy"
+}

--- a/test/fixtures/requires/fixture_test_controller.rb
+++ b/test/fixtures/requires/fixture_test_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class FixtureTestController < Rulers::Controller
+end

--- a/test/fixtures/requires/test_controller.rb
+++ b/test/fixtures/requires/test_controller.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-class TestController < Rulers::Controller
-end

--- a/test/rulers_test.rb
+++ b/test/rulers_test.rb
@@ -52,7 +52,7 @@ class RulersTest < Minitest::Test
   end
 
   def test_autorequire
-    assert_raises(LoadError) { TestController }
+    assert_raises(NameError) { TestController }
     path = File.expand_path("fixtures/requires", __dir__)
     $LOAD_PATH << path
     assert(TestController)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
+$LOAD_PATH.unshift(File.expand_path("./dummy_app/config", __dir__))
+require "dummy_app"
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 require "rulers"
 require "rack/test"
 
 require "minitest/autorun"
+require "byebug"


### PR DESCRIPTION
This PR introduces the Rails-esque view directory structure, of the form `app/views/#{controller_name}/#{action}.html.erb`.

In addition to this, it also changes the test to use a nested dummy app for the test suite. A part of this involved adding a new `Config` class to `Rulers`. For now, the config object is shared at the `Rulers` class level (e.g. shared across the whole Rulers process). Time will tell if this is wise, though I don't see a compelling reason for 2 separate Rulers processes to be running with different configs in the same process.